### PR TITLE
Fix: change '.' notation to '--all' preference

### DIFF
--- a/giteasy
+++ b/giteasy
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "executing git add . command"
-git add .
+git add -A
 echo "excecuting git commit with $1"
 git commit -m "$1"
 


### PR DESCRIPTION
As of Git >2.0:

+ `git add .` only works in only the current directory and its subdirectories (`.` is a UNIX relative path definition, not a Git one).
+ Instead `git add -A` without a `<pathspec>` given runs over the whole working tree.